### PR TITLE
Fixing unhandled error on existing backup file name

### DIFF
--- a/modules/SaveManager.cpp
+++ b/modules/SaveManager.cpp
@@ -382,8 +382,19 @@ void SaveManager::CreateManualBackupPressed() {
     }
 
     std::string savename = ui->ManualSaveLineEdit->text().toStdString();
+
+    if (std::filesystem::exists(BackupsDir / "MANUAL" / savename)){
+        if (QMessageBox::No == QMessageBox::question(this, "Backup File Exists",
+                                                  QString("A backup with this name already exists.\n") +
+                                                  "Do you want to overwrite this backup?",
+                                                  QMessageBox::Yes | QMessageBox::No)) {
+                                                    return;
+                                                  }
+    }
+
     Savefile = ExactSaveDir / saveslot;
-    std::filesystem::copy_file(Savefile, BackupsDir / "MANUAL" / savename);
+    std::filesystem::copy_file(Savefile, BackupsDir / "MANUAL" / savename,
+                                std::filesystem::copy_options::overwrite_existing);
     QMessageBox::information(this, "Save Successful",
                              "Backup save created: " + QString::fromStdString(savename));
 


### PR DESCRIPTION
This PR intends to fix an [issue](https://github.com/rainmakerv3/BB_Launcher/issues/39) I just raised.

Whenever the user tries to create a backup file with a name that matches an existing backup, now we're showing a confirmation window. Also, using a filesystem flag to make sure that the file is overwritten if it already exists.