### PR TITLE
fix correct reference for deleting version files

### DIFF
--- a/modules/version_dialog.cpp
+++ b/modules/version_dialog.cpp
@@ -1268,7 +1268,7 @@ void VersionDialog::RemoveItem(bool alsoDelete) {
         return;
     }
 
-    QString fullPath = selectedItem->text(3);
+    QString fullPath = selectedItem->text(4);
     QString msg;
 
     if (!alsoDelete) {


### PR DESCRIPTION
I noticed that when I removed the version, the entire folder, even the parent files, were deleted. Yes, all my game content, user folders, basically everything Bloodborne-related was deleted. 😆

- It was referencing the date instead of the path; this has been fixed.