### PR TITLE
ModManager: add adhoc to valid BB folders list

### DIFF
--- a/modules/ModDownloader.cpp
+++ b/modules/ModDownloader.cpp
@@ -750,9 +750,10 @@ void ModDownloader::StartDownload(QString url, QString m_modName, bool isPremium
             };
 
             const std::vector<std::string> BBFolders = {
-                "dvdroot_ps4", "action", "chr",    "event", "facegen", "map",   "menu",
-                "movie",       "msg",    "mtd",    "obj",   "other",   "param", "paramdef",
-                "parts",       "remo",   "script", "sfx",   "shader",  "sound", "font"};
+                "dvdroot_ps4", "action", "adhoc",  "chr",    "event",   "facegen", "map",
+                "menu",        "movie",  "msg",    "mtd",    "obj",     "other",   "param",
+                "paramdef",    "parts",  "remo",   "script", "sfx",     "shader",  "sound",
+                "font"};
 
             //  source folder for mods with options
             for (const auto& entry : std::filesystem::recursive_directory_iterator(sourcePath)) {

--- a/modules/ModManager.h
+++ b/modules/ModManager.h
@@ -40,7 +40,8 @@ private:
         Common::GetBBLFilesPath() / "Mods-Active (DO NOT DELETE)";
 
     const std::vector<std::string> BBFolders = {
-        "dvdroot_ps4", "action", "chr",    "event", "facegen", "map",   "menu",
-        "movie",       "msg",    "mtd",    "obj",   "other",   "param", "paramdef",
-        "parts",       "remo",   "script", "sfx",   "shader",  "sound", "font"};
+        "dvdroot_ps4", "action", "adhoc",  "chr",    "event",   "facegen", "map",
+        "menu",        "movie",  "msg",    "mtd",    "obj",     "other",   "param",
+        "paramdef",    "parts",  "remo",   "script", "sfx",     "shader",  "sound",
+        "font"};
 };


### PR DESCRIPTION
## Problem

The Mod Manager validation in `ModManager::ActivateMod` and the mod option validation in `ModDownloader::StartDownload` both check that every top-level folder inside a mod's source path is present in the hardcoded `BBFolders` whitelist. When no folder in the mod matches, the mod is rejected with:

> Folders inside mod folder must include either dvdroot_ps4 or Bloodborne dvdroot_ps4 subfolders (ex. sfx, parts, map).

`BBFolders` currently enumerates every standard Bloodborne `dvdroot_ps4` subdirectory except `adhoc/`, which is used by the game for debug shaders, debug fonts and related assets.

## Effect on real mods

Mods that ship only `adhoc/` content cannot be activated in any structure:

- `Mods/<name>/adhoc/...` — rejected (no match in `BBFolders`).
- `Mods/<name>/dvdroot_ps4/adhoc/...` — the inner folder `adhoc` still does not match.

Example: [Debug Menu Restoration](https://www.nexusmods.com/bloodborne/mods/253) ships only `adhoc/font/`, `adhoc/FontShader/`, `adhoc/GUIShader/` and `adhoc/shader/`. With the current whitelist it cannot be activated through BBLauncher regardless of how it is packaged.

## Fix

Add `"adhoc"` to the `BBFolders` vector in both `modules/ModManager.h` and `modules/ModDownloader.cpp`, matching the existing list in every other way (no other validation logic is touched).

## Tested

GNU/Linux (Gentoo), BBLauncher built locally from this branch. Debug Menu Restoration is now accepted by the Mod Manager and is correctly deployed to `CUSA03173-mods/dvdroot_ps4/adhoc/...`.