### PR TITLE
Add configurable custom user folder option for shadPS4 - CURRENT USER SETTINGS DIR WILL BE RESET

### DIFF
--- a/modules/Common.cpp
+++ b/modules/Common.cpp
@@ -64,7 +64,7 @@ std::filesystem::path GetCurrentPath(bool getLinuxFileName) {
 
 std::filesystem::path GetShadUserDir() {
     if (Config::UserFolderLocation == Config::FolderLocation::CustomFolder &&
-        !Config::CustomUserFolder.empty()) {
+        std::filesystem::exists(Config::CustomUserFolder)) {
         auto user_dir = Config::CustomUserFolder;
         if (!std::filesystem::exists(user_dir))
             std::filesystem::create_directories(user_dir);

--- a/modules/Common.cpp
+++ b/modules/Common.cpp
@@ -63,6 +63,13 @@ std::filesystem::path GetCurrentPath(bool getLinuxFileName) {
 }
 
 std::filesystem::path GetShadUserDir() {
+    if (Config::UseCustomUserFolder && !Config::CustomUserFolder.empty()) {
+        auto user_dir = Config::CustomUserFolder;
+        if (!std::filesystem::exists(user_dir))
+            std::filesystem::create_directories(user_dir);
+        return user_dir;
+    }
+
     std::filesystem::path userPath = Config::PortableFolderinLauncherFolder
                                          ? Common::GetCurrentPath()
                                          : Common::shadPs4Executable.parent_path();

--- a/modules/Common.cpp
+++ b/modules/Common.cpp
@@ -5,6 +5,7 @@
 #include <QProcessEnvironment>
 
 #include "Common.h"
+#include "Log.h"
 #include "scope_exit.h"
 #include "settings/config.h"
 #include "settings/emulator_settings.h"
@@ -63,12 +64,14 @@ std::filesystem::path GetCurrentPath(bool getLinuxFileName) {
 }
 
 std::filesystem::path GetShadUserDir() {
-    if (Config::UserFolderLocation == Config::FolderLocation::CustomFolder &&
-        std::filesystem::exists(Config::CustomUserFolder)) {
-        auto user_dir = Config::CustomUserFolder;
-        if (!std::filesystem::exists(user_dir))
-            std::filesystem::create_directories(user_dir);
-        return user_dir;
+    if (Config::UserFolderLocation == Config::FolderLocation::CustomFolder) {
+        if (std::filesystem::exists(Config::CustomUserFolder)) {
+            auto user_dir = Config::CustomUserFolder;
+            if (!std::filesystem::exists(user_dir))
+                std::filesystem::create_directories(user_dir);
+            return user_dir;
+        }
+        LogWarning("Custom user folder does not exist, falling back to default location");
     }
 
     std::filesystem::path userPath =

--- a/modules/Common.cpp
+++ b/modules/Common.cpp
@@ -63,16 +63,18 @@ std::filesystem::path GetCurrentPath(bool getLinuxFileName) {
 }
 
 std::filesystem::path GetShadUserDir() {
-    if (Config::UseCustomUserFolder && !Config::CustomUserFolder.empty()) {
+    if (Config::UserFolderLocation == Config::FolderLocation::CustomFolder &&
+        !Config::CustomUserFolder.empty()) {
         auto user_dir = Config::CustomUserFolder;
         if (!std::filesystem::exists(user_dir))
             std::filesystem::create_directories(user_dir);
         return user_dir;
     }
 
-    std::filesystem::path userPath = Config::PortableFolderinLauncherFolder
-                                         ? Common::GetCurrentPath()
-                                         : Common::shadPs4Executable.parent_path();
+    std::filesystem::path userPath =
+        Config::UserFolderLocation == Config::FolderLocation::LauncherFolder
+            ? Common::GetCurrentPath()
+            : Common::shadPs4Executable.parent_path();
     auto user_dir = userPath / "user";
 
     if (!std::filesystem::exists(user_dir)) {

--- a/modules/bblauncher.cpp
+++ b/modules/bblauncher.cpp
@@ -422,12 +422,13 @@ void BBLauncher::UpdateSettingsList() {
         "Auto-update shadPS4 version list: " + QVariant(AutoUpdateVersionsEnabled).toString();
 
     QString Location;
-    if (UseCustomUserFolder) {
+    if (UserFolderLocation == FolderLocation::CustomFolder) {
         QString customPath;
         Common::PathToQString(customPath, CustomUserFolder);
         Location = "Custom: " + customPath;
     } else {
-        Location = PortableFolderinLauncherFolder ? "Launcher Folder" : "Build Folder";
+        Location = UserFolderLocation == FolderLocation::LauncherFolder ? "Launcher Folder"
+                                                                        : "Build Folder";
     }
     QString PortableFolderSetting = "Portable Folder Location: " + Location;
 

--- a/modules/bblauncher.cpp
+++ b/modules/bblauncher.cpp
@@ -421,7 +421,14 @@ void BBLauncher::UpdateSettingsList() {
     QString AutoUpdateVersionsSetting =
         "Auto-update shadPS4 version list: " + QVariant(AutoUpdateVersionsEnabled).toString();
 
-    QString Location = PortableFolderinLauncherFolder ? "Launcher Folder" : "Build Folder";
+    QString Location;
+    if (UseCustomUserFolder) {
+        QString customPath;
+        Common::PathToQString(customPath, CustomUserFolder);
+        Location = "Custom: " + customPath;
+    } else {
+        Location = PortableFolderinLauncherFolder ? "Launcher Folder" : "Build Folder";
+    }
     QString PortableFolderSetting = "Portable Folder Location: " + Location;
 
     QString BackupIntSetting;

--- a/modules/ipc/ipc_client.cpp
+++ b/modules/ipc/ipc_client.cpp
@@ -35,7 +35,7 @@ void IpcClient::startEmulator(const QFileInfo& exe, const QStringList& args,
 
     std::filesystem::path userPath;
     if (Config::UserFolderLocation == Config::FolderLocation::CustomFolder &&
-        !Config::CustomUserFolder.empty()) {
+        std::filesystem::exists(Config::CustomUserFolder)) {
         userPath = Config::CustomUserFolder.parent_path();
     } else {
         userPath = Config::UserFolderLocation == Config::FolderLocation::LauncherFolder

--- a/modules/ipc/ipc_client.cpp
+++ b/modules/ipc/ipc_client.cpp
@@ -33,9 +33,14 @@ void IpcClient::startEmulator(const QFileInfo& exe, const QStringList& args,
     env.insert("SHADPS4_ENABLE_IPC", "true");
     process->setProcessEnvironment(env);
 
-    std::filesystem::path userPath = Config::PortableFolderinLauncherFolder
-                                         ? Common::GetCurrentPath()
-                                         : Common::shadPs4Executable.parent_path();
+    std::filesystem::path userPath;
+    if (Config::UseCustomUserFolder && !Config::CustomUserFolder.empty()) {
+        userPath = Config::CustomUserFolder.parent_path();
+    } else {
+        userPath = Config::PortableFolderinLauncherFolder
+                       ? Common::GetCurrentPath()
+                       : Common::shadPs4Executable.parent_path();
+    }
 
     QString userDir;
     Common::PathToQString(userDir, userPath);

--- a/modules/ipc/ipc_client.cpp
+++ b/modules/ipc/ipc_client.cpp
@@ -38,7 +38,8 @@ void IpcClient::startEmulator(const QFileInfo& exe, const QStringList& args,
         if (std::filesystem::exists(Config::CustomUserFolder)) {
             userPath = Config::CustomUserFolder.parent_path();
         } else {
-            LogWarning("Custom user folder does not exist, falling back to default location");
+            emit LogEntrySent(
+                "Custom user folder does not exist, falling back to default location");
             userPath = Common::shadPs4Executable.parent_path();
         }
     } else {

--- a/modules/ipc/ipc_client.cpp
+++ b/modules/ipc/ipc_client.cpp
@@ -34,9 +34,13 @@ void IpcClient::startEmulator(const QFileInfo& exe, const QStringList& args,
     process->setProcessEnvironment(env);
 
     std::filesystem::path userPath;
-    if (Config::UserFolderLocation == Config::FolderLocation::CustomFolder &&
-        std::filesystem::exists(Config::CustomUserFolder)) {
-        userPath = Config::CustomUserFolder.parent_path();
+    if (Config::UserFolderLocation == Config::FolderLocation::CustomFolder) {
+        if (std::filesystem::exists(Config::CustomUserFolder)) {
+            userPath = Config::CustomUserFolder.parent_path();
+        } else {
+            LogWarning("Custom user folder does not exist, falling back to default location");
+            userPath = Common::shadPs4Executable.parent_path();
+        }
     } else {
         userPath = Config::UserFolderLocation == Config::FolderLocation::LauncherFolder
                        ? Common::GetCurrentPath()

--- a/modules/ipc/ipc_client.cpp
+++ b/modules/ipc/ipc_client.cpp
@@ -34,10 +34,11 @@ void IpcClient::startEmulator(const QFileInfo& exe, const QStringList& args,
     process->setProcessEnvironment(env);
 
     std::filesystem::path userPath;
-    if (Config::UseCustomUserFolder && !Config::CustomUserFolder.empty()) {
+    if (Config::UserFolderLocation == Config::FolderLocation::CustomFolder &&
+        !Config::CustomUserFolder.empty()) {
         userPath = Config::CustomUserFolder.parent_path();
     } else {
-        userPath = Config::PortableFolderinLauncherFolder
+        userPath = Config::UserFolderLocation == Config::FolderLocation::LauncherFolder
                        ? Common::GetCurrentPath()
                        : Common::shadPs4Executable.parent_path();
     }

--- a/settings/LauncherSettings.cpp
+++ b/settings/LauncherSettings.cpp
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright 2024 BBLauncher Project
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include <QFileDialog>
 #include <QFileInfo>
 #include <QMessageBox>
 #include <QPushButton>
@@ -32,13 +33,40 @@ LauncherSettings::LauncherSettings(QWidget* parent)
     ui->BackupIntervalComboBox->addItems(BackupFreqList);
     ui->BackupNumberComboBox->addItems(BackupNumList);
 
+    std::string fallbackPath;
+#ifdef __APPLE__
+    fallbackPath = "~/Library/Application Support/shadPS4";
+#elif defined(__linux__)
+    const char* xdg = getenv("XDG_DATA_HOME");
+    fallbackPath = (xdg && strlen(xdg) > 0)
+                       ? std::string(xdg) + "/shadPS4"
+                       : "~/.local/share/shadPS4";
+#elif _WIN32
+    TCHAR appdata[MAX_PATH] = {0};
+    SHGetFolderPath(NULL, CSIDL_APPDATA, NULL, 0, appdata);
+    QString fallbackQStr;
+    Common::PathToQString(fallbackQStr, std::filesystem::path(appdata) / "shadPS4");
+    fallbackPath = fallbackQStr.toStdString();
+#endif
+    QString desc = ui->LauncherSetDescText->toHtml();
+    desc.replace("%FALLBACK%", QString::fromStdString(fallbackPath));
+    ui->LauncherSetDescText->setHtml(desc);
+
     if (theme == "Dark") {
         ui->DarkThemeRadioButton->setChecked(true);
     } else {
         ui->LightThemeRadioButton->setChecked(true);
     }
 
-    if (PortableFolderinLauncherFolder) {
+    QString customPath;
+    Common::PathToQString(customPath, CustomUserFolder);
+    ui->CustomFolderLineEdit->setText(customPath);
+
+    if (UseCustomUserFolder) {
+        ui->CustomFolderRadioButton->setChecked(true);
+        ui->CustomFolderLineEdit->setEnabled(true);
+        ui->BrowseCustomFolderButton->setEnabled(true);
+    } else if (PortableFolderinLauncherFolder) {
         ui->PortableLauncherRadioButton->setChecked(true);
     } else {
         ui->PortableBuildRadioButton->setChecked(true);
@@ -70,6 +98,28 @@ LauncherSettings::LauncherSettings(QWidget* parent)
             &LauncherSettings::OnBackupStateChanged);
 
     connect(ui->shortcutButton, &QPushButton::clicked, this, &LauncherSettings::CreateShortcut);
+
+    connect(ui->BrowseCustomFolderButton, &QPushButton::clicked, this,
+            &LauncherSettings::BrowseCustomFolder);
+
+    connect(ui->CustomFolderRadioButton, &QRadioButton::toggled, this, [this](bool checked) {
+        ui->CustomFolderLineEdit->setEnabled(checked);
+        ui->BrowseCustomFolderButton->setEnabled(checked);
+    });
+
+    connect(ui->PortableBuildRadioButton, &QRadioButton::toggled, this, [this](bool checked) {
+        if (checked) {
+            ui->CustomFolderLineEdit->setEnabled(false);
+            ui->BrowseCustomFolderButton->setEnabled(false);
+        }
+    });
+
+    connect(ui->PortableLauncherRadioButton, &QRadioButton::toggled, this, [this](bool checked) {
+        if (checked) {
+            ui->CustomFolderLineEdit->setEnabled(false);
+            ui->BrowseCustomFolderButton->setEnabled(false);
+        }
+    });
 }
 
 void LauncherSettings::SetLauncherDefaults() {
@@ -78,6 +128,10 @@ void LauncherSettings::SetLauncherDefaults() {
     ui->SoundFixCheckBox->setChecked(true);
     ui->BackupIntervalComboBox->setCurrentText("10");
     ui->BackupNumberComboBox->setCurrentText("2");
+    ui->PortableBuildRadioButton->setChecked(true);
+    ui->CustomFolderLineEdit->clear();
+    ui->CustomFolderLineEdit->setEnabled(false);
+    ui->BrowseCustomFolderButton->setEnabled(false);
 }
 
 void LauncherSettings::SaveSettings() {
@@ -109,6 +163,9 @@ void LauncherSettings::SaveSettings() {
     }
 
     PortableFolderinLauncherFolder = ui->PortableLauncherRadioButton->isChecked();
+    UseCustomUserFolder = ui->CustomFolderRadioButton->isChecked();
+    CustomUserFolder =
+        Common::PathFromQString(ui->CustomFolderLineEdit->text());
     SoundFixEnabled = ui->SoundFixCheckBox->isChecked();
     AutoUpdateEnabled = ui->UpdateCheckBox->isChecked();
 
@@ -302,6 +359,24 @@ bool LauncherSettings::createShortcutLinux(const QString& linkPath, const std::s
     return true;
 }
 #endif
+
+void LauncherSettings::BrowseCustomFolder() {
+    QString dir = QFileDialog::getExistingDirectory(
+        this, tr("Select shadPS4 User Folder"),
+        ui->CustomFolderLineEdit->text().isEmpty() ? QString()
+                                                   : ui->CustomFolderLineEdit->text());
+    if (!dir.isEmpty()) {
+        std::filesystem::path selectedPath = Common::PathFromQString(dir);
+        if (!std::filesystem::exists(selectedPath / "config.json")) {
+            QMessageBox::warning(
+                this, tr("Invalid User Folder"),
+                tr("The selected folder does not contain a config.json file.\n"
+                   "Make sure this is the shadPS4 user folder with config.json, "
+                   "cache/, patches/, etc."));
+        }
+        ui->CustomFolderLineEdit->setText(dir);
+    }
+}
 
 LauncherSettings::~LauncherSettings() {
     delete ui;

--- a/settings/LauncherSettings.cpp
+++ b/settings/LauncherSettings.cpp
@@ -62,11 +62,11 @@ LauncherSettings::LauncherSettings(QWidget* parent)
     Common::PathToQString(customPath, CustomUserFolder);
     ui->CustomFolderLineEdit->setText(customPath);
 
-    if (UseCustomUserFolder) {
+    if (UserFolderLocation == FolderLocation::CustomFolder) {
         ui->CustomFolderRadioButton->setChecked(true);
         ui->CustomFolderLineEdit->setEnabled(true);
         ui->BrowseCustomFolderButton->setEnabled(true);
-    } else if (PortableFolderinLauncherFolder) {
+    } else if (UserFolderLocation == FolderLocation::LauncherFolder) {
         ui->PortableLauncherRadioButton->setChecked(true);
     } else {
         ui->PortableBuildRadioButton->setChecked(true);
@@ -162,8 +162,13 @@ void LauncherSettings::SaveSettings() {
         theme = "Light";
     }
 
-    PortableFolderinLauncherFolder = ui->PortableLauncherRadioButton->isChecked();
-    UseCustomUserFolder = ui->CustomFolderRadioButton->isChecked();
+    if (ui->CustomFolderRadioButton->isChecked()) {
+        UserFolderLocation = FolderLocation::CustomFolder;
+    } else if (ui->PortableLauncherRadioButton->isChecked()) {
+        UserFolderLocation = FolderLocation::LauncherFolder;
+    } else {
+        UserFolderLocation = FolderLocation::BuildFolder;
+    }
     CustomUserFolder =
         Common::PathFromQString(ui->CustomFolderLineEdit->text());
     SoundFixEnabled = ui->SoundFixCheckBox->isChecked();

--- a/settings/LauncherSettings.h
+++ b/settings/LauncherSettings.h
@@ -19,6 +19,7 @@ public slots:
 private slots:
     void SetLauncherDefaults();
     void SaveSettings();
+    void BrowseCustomFolder();
 
 private:
     Ui::LauncherSettings* ui;

--- a/settings/LauncherSettings.ui
+++ b/settings/LauncherSettings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>591</width>
-    <height>629</height>
+    <height>690</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -19,7 +19,7 @@
      <x>10</x>
      <y>10</y>
      <width>565</width>
-     <height>609</height>
+     <height>670</height>
     </rect>
    </property>
    <layout class="QHBoxLayout" name="horizontalLayout">
@@ -155,14 +155,45 @@
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QRadioButton" name="PortableLauncherRadioButton">
-           <property name="text">
-            <string>In BBLauncher folder</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
+          <item>
+           <widget class="QRadioButton" name="PortableLauncherRadioButton">
+            <property name="text">
+             <string>In BBLauncher folder</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="CustomFolderRadioButton">
+            <property name="text">
+             <string>Custom folder</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="customFolderLayout">
+            <item>
+             <widget class="QLineEdit" name="CustomFolderLineEdit">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="BrowseCustomFolderButton">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Browse...</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
        </widget>
       </item>
      </layout>
@@ -201,8 +232,10 @@ li.checked::marker { content: &quot;\2612&quot;; }
 &lt;p style=&quot; margin-top:6px; margin-bottom:6px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Fixes some sounds not working after a crash when the 60 FPS patch is enabled.&lt;/p&gt;
 &lt;p style=&quot; margin-top:6px; margin-bottom:6px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Backup Saves:&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:6px; margin-bottom:6px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Automatically transfers Bloodborne saves to backup folders in the BBLauncher/Backups folder. BACKUP1 will always be the newest, then BACKUP2 and so on. You can restore backups folders from the Save Manager.&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Set Portable (&amp;quot;user&amp;quot;) Folder Location&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Set which location BBLauncher should read the shadPS4 portable settings folder in&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Set User Folder Location&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Build folder&lt;/span&gt; (default): the &amp;quot;user&amp;quot; folder is expected inside the same folder as the shadPS4 executable. If not found, falls back to %FALLBACK%.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Launcher folder&lt;/span&gt;: the &amp;quot;user&amp;quot; folder is created/read inside the BBLauncher folder. If not found, falls back to %FALLBACK%.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;Custom folder&lt;/span&gt;: choose any folder on disk. The folder is used directly as the user folder (must contain config.json, cache/, patches/, etc.). No fallback to roaming.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="acceptRichText">
             <bool>false</bool>

--- a/settings/config.cpp
+++ b/settings/config.cpp
@@ -75,12 +75,9 @@ void LoadSettings() {
 
     SoundFixEnabled = toml::find_or<bool>(data, "Launcher", "SoundFixEnabled", true);
     AutoUpdateEnabled = toml::find_or<bool>(data, "Launcher", "AutoUpdateEnabled", false);
-    int userFolderLoc = toml::find_or<int>(data, "Launcher", "UserFolderLocation",
-                                           static_cast<int>(FolderLocation::BuildFolder));
-    if (userFolderLoc >= static_cast<int>(FolderLocation::BuildFolder) &&
-        userFolderLoc <= static_cast<int>(FolderLocation::CustomFolder)) {
-        UserFolderLocation = static_cast<FolderLocation>(userFolderLoc);
-    }
+    UserFolderLocation = static_cast<FolderLocation>(
+        toml::find_or<int>(data, "Launcher", "UserFolderLocation",
+                           static_cast<int>(FolderLocation::BuildFolder)));
 
     BackupSaveEnabled = toml::find_or<bool>(data, "Backups", "BackupSaveEnabled", false);
     BackupInterval = toml::find_or<int>(data, "Backups", "BackupInterval", 10);

--- a/settings/config.cpp
+++ b/settings/config.cpp
@@ -75,21 +75,11 @@ void LoadSettings() {
 
     SoundFixEnabled = toml::find_or<bool>(data, "Launcher", "SoundFixEnabled", true);
     AutoUpdateEnabled = toml::find_or<bool>(data, "Launcher", "AutoUpdateEnabled", false);
-    int userFolderLoc = toml::find_or<int>(data, "Launcher", "UserFolderLocation", -1);
-    if (userFolderLoc >= 0) {
+    int userFolderLoc = toml::find_or<int>(data, "Launcher", "UserFolderLocation",
+                                           static_cast<int>(FolderLocation::BuildFolder));
+    if (userFolderLoc >= static_cast<int>(FolderLocation::BuildFolder) &&
+        userFolderLoc <= static_cast<int>(FolderLocation::CustomFolder)) {
         UserFolderLocation = static_cast<FolderLocation>(userFolderLoc);
-    } else {
-        bool portableInLauncher =
-            toml::find_or<bool>(data, "Launcher", "PortableFolderinLauncherFolder", false);
-        bool useCustom =
-            toml::find_or<bool>(data, "Launcher", "UseCustomUserFolder", false);
-        if (useCustom) {
-            UserFolderLocation = FolderLocation::CustomFolder;
-        } else if (portableInLauncher) {
-            UserFolderLocation = FolderLocation::LauncherFolder;
-        } else {
-            UserFolderLocation = FolderLocation::BuildFolder;
-        }
     }
 
     BackupSaveEnabled = toml::find_or<bool>(data, "Backups", "BackupSaveEnabled", false);
@@ -278,12 +268,6 @@ void SaveLauncherSettings() {
     data["Launcher"]["UserFolderLocation"] = static_cast<int>(UserFolderLocation);
     data["Launcher"]["CustomUserFolder"] =
         std::string{fmt::UTF(CustomUserFolder.u8string()).data};
-    if (data["Launcher"].contains("PortableFolderinLauncherFolder")) {
-        data["Launcher"].as_table().erase("PortableFolderinLauncherFolder");
-    }
-    if (data["Launcher"].contains("UseCustomUserFolder")) {
-        data["Launcher"].as_table().erase("UseCustomUserFolder");
-    }
 
     data["Backups"]["BackupSaveEnabled"] = BackupSaveEnabled;
     data["Backups"]["BackupInterval"] = BackupInterval;

--- a/settings/config.cpp
+++ b/settings/config.cpp
@@ -17,8 +17,7 @@ std::string Config::ApiKey = "";
 std::string Config::theme = "Dark";
 bool Config::SoundFixEnabled = true;
 bool Config::AutoUpdateEnabled = false;
-bool Config::PortableFolderinLauncherFolder = false;
-bool Config::UseCustomUserFolder = false;
+Config::FolderLocation Config::UserFolderLocation = Config::FolderLocation::BuildFolder;
 std::filesystem::path Config::CustomUserFolder;
 
 bool Config::BackupSaveEnabled = false;
@@ -76,10 +75,22 @@ void LoadSettings() {
 
     SoundFixEnabled = toml::find_or<bool>(data, "Launcher", "SoundFixEnabled", true);
     AutoUpdateEnabled = toml::find_or<bool>(data, "Launcher", "AutoUpdateEnabled", false);
-    PortableFolderinLauncherFolder =
-        toml::find_or<bool>(data, "Launcher", "PortableFolderinLauncherFolder", false);
-    UseCustomUserFolder =
-        toml::find_or<bool>(data, "Launcher", "UseCustomUserFolder", false);
+    int userFolderLoc = toml::find_or<int>(data, "Launcher", "UserFolderLocation", -1);
+    if (userFolderLoc >= 0) {
+        UserFolderLocation = static_cast<FolderLocation>(userFolderLoc);
+    } else {
+        bool portableInLauncher =
+            toml::find_or<bool>(data, "Launcher", "PortableFolderinLauncherFolder", false);
+        bool useCustom =
+            toml::find_or<bool>(data, "Launcher", "UseCustomUserFolder", false);
+        if (useCustom) {
+            UserFolderLocation = FolderLocation::CustomFolder;
+        } else if (portableInLauncher) {
+            UserFolderLocation = FolderLocation::LauncherFolder;
+        } else {
+            UserFolderLocation = FolderLocation::BuildFolder;
+        }
+    }
 
     BackupSaveEnabled = toml::find_or<bool>(data, "Backups", "BackupSaveEnabled", false);
     BackupInterval = toml::find_or<int>(data, "Backups", "BackupInterval", 10);
@@ -264,10 +275,15 @@ void SaveLauncherSettings() {
     data["Launcher"]["installPath"] = std::string{fmt::UTF(Common::installPath.u8string()).data};
     data["Launcher"]["shadPath-New"] =
         std::string{fmt::UTF(Common::shadPs4Executable.u8string()).data};
-    data["Launcher"]["PortableFolderinLauncherFolder"] = PortableFolderinLauncherFolder;
-    data["Launcher"]["UseCustomUserFolder"] = UseCustomUserFolder;
+    data["Launcher"]["UserFolderLocation"] = static_cast<int>(UserFolderLocation);
     data["Launcher"]["CustomUserFolder"] =
         std::string{fmt::UTF(CustomUserFolder.u8string()).data};
+    if (data["Launcher"].contains("PortableFolderinLauncherFolder")) {
+        data["Launcher"].as_table().erase("PortableFolderinLauncherFolder");
+    }
+    if (data["Launcher"].contains("UseCustomUserFolder")) {
+        data["Launcher"].as_table().erase("UseCustomUserFolder");
+    }
 
     data["Backups"]["BackupSaveEnabled"] = BackupSaveEnabled;
     data["Backups"]["BackupInterval"] = BackupInterval;

--- a/settings/config.cpp
+++ b/settings/config.cpp
@@ -18,6 +18,8 @@ std::string Config::theme = "Dark";
 bool Config::SoundFixEnabled = true;
 bool Config::AutoUpdateEnabled = false;
 bool Config::PortableFolderinLauncherFolder = false;
+bool Config::UseCustomUserFolder = false;
+std::filesystem::path Config::CustomUserFolder;
 
 bool Config::BackupSaveEnabled = false;
 int Config::BackupInterval = 10;
@@ -76,6 +78,8 @@ void LoadSettings() {
     AutoUpdateEnabled = toml::find_or<bool>(data, "Launcher", "AutoUpdateEnabled", false);
     PortableFolderinLauncherFolder =
         toml::find_or<bool>(data, "Launcher", "PortableFolderinLauncherFolder", false);
+    UseCustomUserFolder =
+        toml::find_or<bool>(data, "Launcher", "UseCustomUserFolder", false);
 
     BackupSaveEnabled = toml::find_or<bool>(data, "Backups", "BackupSaveEnabled", false);
     BackupInterval = toml::find_or<int>(data, "Backups", "BackupInterval", 10);
@@ -97,6 +101,7 @@ void LoadSettings() {
         SevenZipPath = toml::find_fs_path_or(launcher, "SevenZipPath", {});
         Common::installPath = toml::find_fs_path_or(launcher, "installPath", {});
         Common::shadPs4Executable = toml::find_fs_path_or(launcher, "shadPath-New", {});
+        CustomUserFolder = toml::find_fs_path_or(launcher, "CustomUserFolder", {});
     }
 
     if (std::filesystem::exists(Common::installPath)) {
@@ -260,6 +265,9 @@ void SaveLauncherSettings() {
     data["Launcher"]["shadPath-New"] =
         std::string{fmt::UTF(Common::shadPs4Executable.u8string()).data};
     data["Launcher"]["PortableFolderinLauncherFolder"] = PortableFolderinLauncherFolder;
+    data["Launcher"]["UseCustomUserFolder"] = UseCustomUserFolder;
+    data["Launcher"]["CustomUserFolder"] =
+        std::string{fmt::UTF(CustomUserFolder.u8string()).data};
 
     data["Backups"]["BackupSaveEnabled"] = BackupSaveEnabled;
     data["Backups"]["BackupInterval"] = BackupInterval;

--- a/settings/config.h
+++ b/settings/config.h
@@ -9,6 +9,12 @@
 
 namespace Config {
 
+enum class FolderLocation {
+    BuildFolder,
+    LauncherFolder,
+    CustomFolder,
+};
+
 struct Build {
     std::string path;
     std::string type;
@@ -33,8 +39,7 @@ void SaveLauncherSettings();
 std::string GetLastModifiedString(const std::filesystem::path& path);
 
 extern std::string theme;
-extern bool PortableFolderinLauncherFolder;
-extern bool UseCustomUserFolder;
+extern FolderLocation UserFolderLocation;
 extern std::filesystem::path CustomUserFolder;
 extern bool SoundFixEnabled;
 extern bool BackupSaveEnabled;

--- a/settings/config.h
+++ b/settings/config.h
@@ -34,6 +34,8 @@ std::string GetLastModifiedString(const std::filesystem::path& path);
 
 extern std::string theme;
 extern bool PortableFolderinLauncherFolder;
+extern bool UseCustomUserFolder;
+extern std::filesystem::path CustomUserFolder;
 extern bool SoundFixEnabled;
 extern bool BackupSaveEnabled;
 extern int BackupInterval;


### PR DESCRIPTION
This pull request adds support for specifying a custom user folder location for shadPS4, in addition to the existing options (build folder and launcher folder). The changes include updates to the settings UI, configuration handling, and logic throughout the codebase to support selecting, saving, and using a user-defined folder for shadPS4 data.

**User Folder Customization:**

* Added a "Custom folder" option to the launcher settings UI, including a radio button, a read-only line edit to display the selected path, and a "Browse..." button to select a directory. The UI dynamically enables/disables controls based on the selected option. (`settings/LauncherSettings.ui`, `settings/LauncherSettings.cpp`) [[1]](diffhunk://#diff-a2f6bf95b47f696fc9ea8b6851593cb69e6800dfe4f7a8034a8525623cf251f8R165-R195) [[2]](diffhunk://#diff-a2f6bf95b47f696fc9ea8b6851593cb69e6800dfe4f7a8034a8525623cf251f8L204-R238) [[3]](diffhunk://#diff-1e39c23c4c96e1c1d919712a1d99c9ae3d7c04e6467d244672e8849b1a40c907R36-R69) [[4]](diffhunk://#diff-1e39c23c4c96e1c1d919712a1d99c9ae3d7c04e6467d244672e8849b1a40c907R101-R122) [[5]](diffhunk://#diff-1e39c23c4c96e1c1d919712a1d99c9ae3d7c04e6467d244672e8849b1a40c907R131-R134)
* Implemented logic to save and load the custom user folder path and selection state in the configuration, including TOML serialization/deserialization. (`settings/config.cpp`, `settings/config.h`) [[1]](diffhunk://#diff-bf0e9eb7623d9fcb2dede8a4d58ddb5b52d4a3403fbe984d90a986a7563b272dR21-R22) [[2]](diffhunk://#diff-bf0e9eb7623d9fcb2dede8a4d58ddb5b52d4a3403fbe984d90a986a7563b272dR81-R82) [[3]](diffhunk://#diff-bf0e9eb7623d9fcb2dede8a4d58ddb5b52d4a3403fbe984d90a986a7563b272dR104) [[4]](diffhunk://#diff-bf0e9eb7623d9fcb2dede8a4d58ddb5b52d4a3403fbe984d90a986a7563b272dR268-R270) [[5]](diffhunk://#diff-3c285135be8af554681692ce6ee36ea208e17ce255097514333b354f2c0d50e2R37-R38)
* Updated the summary and description in the settings dialog to explain the three user folder location options and their fallback behavior. (`settings/LauncherSettings.ui`, `settings/LauncherSettings.cpp`) [[1]](diffhunk://#diff-a2f6bf95b47f696fc9ea8b6851593cb69e6800dfe4f7a8034a8525623cf251f8L204-R238) [[2]](diffhunk://#diff-1e39c23c4c96e1c1d919712a1d99c9ae3d7c04e6467d244672e8849b1a40c907R36-R69)

**Integration with Core Logic:**

* Modified functions that determine the user folder path to check for and use the custom folder if set, including creating the directory if it doesn't exist. (`modules/Common.cpp`, `modules/ipc/ipc_client.cpp`, `modules/bblauncher.cpp`) [[1]](diffhunk://#diff-e432e82f8ae25c8a9de2585165c5efc43985dd314fb0a546c2ea529d860cd605R66-R72) [[2]](diffhunk://#diff-a30228e919a8508d97879baa0bedd08c052a7479668b176920aac716d3b2628aL36-R43) [[3]](diffhunk://#diff-92cd09f957ea35fd6c460d61e89dbfdf1f5e8b8f511d8077f886f500adc4945aL424-R431)

**Usability Improvements:**

* Added a folder browser dialog for selecting the custom user folder, with validation that the selected folder contains a `config.json` file. (`settings/LauncherSettings.cpp`, `settings/LauncherSettings.h`) [[1]](diffhunk://#diff-1e39c23c4c96e1c1d919712a1d99c9ae3d7c04e6467d244672e8849b1a40c907R363-R380) [[2]](diffhunk://#diff-09f7d23f54169bc4db174f5d1f0dff9108e0a0af9efc9843916ee4184b3eac57R22)

These changes make it easier for users to specify exactly where their shadPS4 data is stored, improving flexibility for advanced setups and multi-user environments.

Related to #85